### PR TITLE
Added optional player argument to /ba kit:

### DIFF
--- a/src/main/java/net/huskycraft/blockyarena/BlockyArena.java
+++ b/src/main/java/net/huskycraft/blockyarena/BlockyArena.java
@@ -169,7 +169,10 @@ public final class BlockyArena {
                 .build();
 
         CommandSpec cmdKit = CommandSpec.builder()
-                .arguments(GenericArguments.onlyOne(GenericArguments.string(Text.of("id"))))
+                .arguments(
+                        GenericArguments.onlyOne(GenericArguments.string(Text.of("id"))),
+                        GenericArguments.optionalWeak(GenericArguments.playerOrSource(Text.of("player")))
+                )
                 .executor(CmdKit.getInstance())
                 .build();
 

--- a/src/main/java/net/huskycraft/blockyarena/commands/CmdKit.java
+++ b/src/main/java/net/huskycraft/blockyarena/commands/CmdKit.java
@@ -27,6 +27,8 @@ import org.spongepowered.api.command.spec.CommandExecutor;
 import org.spongepowered.api.entity.living.player.Player;
 import org.spongepowered.api.text.Text;
 
+import java.util.Optional;
+
 public class CmdKit implements CommandExecutor {
 
     private static final CmdKit INSTANCE = new CmdKit();
@@ -41,7 +43,22 @@ public class CmdKit implements CommandExecutor {
 
     @Override
     public CommandResult execute(CommandSource src, CommandContext args) throws CommandException {
-        Player player = (Player)src;
+        Player player;
+        Optional<Player> playerArg = args.getOne(Text.of("player"));
+
+        if (src instanceof Player) {
+            if (playerArg.isPresent() && src != playerArg.get()) {
+                src.sendMessage(Text.of("You are not allowed to set another player's kit."));
+                return CommandResult.empty();
+            }
+            player = (Player)src;
+        } else {
+            if (!playerArg.isPresent()) {
+                return CommandResult.empty();
+            }
+            player = playerArg.get();
+        }
+
         if (GamersManager.getGamer(player.getUniqueId()).get().getStatus() != GamerStatus.PLAYING) {
             player.sendMessage(Text.of("You are not allowed to get any kit when you are not in a game."));
             return CommandResult.empty();


### PR DESCRIPTION
**Context**
I installed the plugin. Started to test with it. _Wow, this is pretty cool!_ I thought. Built a large arena building that contained several arenas. Made several different kits. In the lobby area, I setup command blocks with buttons that will allow each player to quickly and easily change their kits.

Pressing the button revealed to me that _command blocks could not set a player's kit!!_ 😱 . A single tear rolled down my cheek. It was that instant that I know I had to fork, and change that. And so thats what I done!

I don't know if this was intended or not, but I feel like allowing an optional player argument for the /kit command would be beneficial. This would allow command blocks to target a player and give them a kit (and avoid my sadness from above).

**Features**
- Allows consoles/command blocks to target a specific player:
  - Players cannot target other players. They will get a message saying they do not have permission